### PR TITLE
Fix path expatnsion for script directory

### DIFF
--- a/virtualz.plugin.zsh
+++ b/virtualz.plugin.zsh
@@ -8,7 +8,7 @@
 
 : ${VIRTUALZ_HOME:=${HOME}/.virtualenvs}
 
-typeset -gr _virtualz_dir=${0:A}
+typeset -gr _virtualz_dir=${0:A:h}
 
 vz () {
 	if [[ $# -eq 0 || $1 = --help || $1 == -h ]] ; then


### PR DESCRIPTION
Even after a previous change that I requested, the fix actually broke
many of the completion and help options for virtualz. This fixes pathing
so that the virtualz script can find its documentation.

I have verified this on my setup.

To verify:

1. run vz --help without the patch to see that it breaks
2. apply patch
3. run vz --help with patch to verify that it prints help messages properly.