### PR TITLE
Add New VZ command

### DIFF
--- a/doc/cmd-current.txt
+++ b/doc/cmd-current.txt
@@ -1,4 +1,4 @@
-List the current virtualenv
+Show the current virtualenv
 Usage: vz current
 
 Shows the name of the activated virtualenv.

--- a/doc/cmd-current.txt
+++ b/doc/cmd-current.txt
@@ -1,0 +1,4 @@
+List the current virtualenv
+Usage: vz current
+
+Shows the name of the activated virtualenv.

--- a/virtualz.plugin.zsh
+++ b/virtualz.plugin.zsh
@@ -136,6 +136,7 @@ virtualz-ls () {
 	fi
 }
 
+
 virtualz-_exists () {
 	if [[ $# -lt 1 ]] ; then
 		echo 'No virtualenv specified.' 1>&2
@@ -150,6 +151,14 @@ virtualz-cd () {
 		return 1
 	fi
 	cd "${VIRTUAL_ENV}"
+}
+
+virtualz-current() { 
+	if [[ ${VIRTUAL_ENV:+set} != set ]] ; then
+		echo 'No virtualenv is active.' 1>&2
+		return 1
+	fi
+	echo "${VIRTUAL_ENV_NAME}"
 }
 
 virtualz-help () {

--- a/virtualz.plugin.zsh
+++ b/virtualz.plugin.zsh
@@ -136,7 +136,6 @@ virtualz-ls () {
 	fi
 }
 
-
 virtualz-_exists () {
 	if [[ $# -lt 1 ]] ; then
 		echo 'No virtualenv specified.' 1>&2

--- a/virtualz.plugin.zsh
+++ b/virtualz.plugin.zsh
@@ -152,7 +152,7 @@ virtualz-cd () {
 	cd "${VIRTUAL_ENV}"
 }
 
-virtualz-current() { 
+virtualz-current () { 
 	if [[ ${VIRTUAL_ENV:+set} != set ]] ; then
 		echo 'No virtualenv is active.' 1>&2
 		return 1


### PR DESCRIPTION
#### Add new vz command

Adds a new command, `vz current`, which lists the currently activated virtualenv. This is a small feature I added for my own use and thought I might as well pass it along.

#### What should the reviewer look for?

 - A new function, `virtualz-current` in `virtualz.plugin.zsh`
 - A new cmd file in `docs/` with information about the new command

Thanks for considering my PR!